### PR TITLE
POD: fix NAME section

### DIFF
--- a/lib/Devel/SizeMe.pm
+++ b/lib/Devel/SizeMe.pm
@@ -45,7 +45,7 @@ END {
 1;
 __END__
 
-=pod
+=head1 NAME
 
 Devel::SizeMe - Extension for extracting detailed memory usage information
 


### PR DESCRIPTION
Fixes the NAME section of the POD in Devel::SizeMe.
