### PR TITLE
[travis] Add a basic continuous integration config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: "perl"
+perl:
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
+before_script:
+
+#env:


### PR DESCRIPTION
This adds a basic Travis CI config file and gets Devel::SizeMe tests running on Perl 5.10, 5.12, 5.14 and 5.16 on each commit.

Example Travis CI run: https://travis-ci.org/#!/letolabs/devel-sizeme/jobs/2997834
