### PR TITLE
fix can't locate object method "render_json"

### DIFF
--- a/bin/sizeme_graph.pl
+++ b/bin/sizeme_graph.pl
@@ -134,7 +134,7 @@ get '/jit_tree/:id/:depth' => sub {
         Dwarn(Storable::dclone($jit_tree)); # dclone to avoid stringification
     }
 
-    $self->render_json($jit_tree);
+    $self->render(json=>$jit_tree);
 };
 
 my %node_queue;


### PR DESCRIPTION
According to the Mojolicious webpage, rendering json uses the render() function:

[error] Can't locate object method "render_json" via package "Mojolicious::Controller" at /Users/.../perl5/bin/sizeme_graph.pl line 141.
